### PR TITLE
Move config from Dockerfile to compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,19 +13,3 @@ COPY hitobito/Wagonfile.ci ./Wagonfile
 COPY hitobito/Gemfile hitobito/Gemfile.lock ./
 RUN gem install --prerelease ruby-debug-ide && gem install debase
 RUN bundle install
-
-####################################################################
-FROM base as dev
-
-ENV RAILS_ENV=development
-
-ENTRYPOINT [ "/app/.docker/entrypoint" ]
-CMD [ "rails", "server", "-b", "0.0.0.0" ]
-
-####################################################################
-FROM base as test
-
-ENV RAILS_ENV=test
-
-ENTRYPOINT [ "/app/.docker/entrypoint" ]
-CMD [ "rspec" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,23 @@
 version: '3.4'
 services:
   app: &app
-    build:
-      context: .
-      target: dev
+    build: .
     depends_on:
     - db
     - mail
     - cache
     - worker
     env_file: .docker/app.env
+    environment:
+      RAILS_ENV: development
+    entrypoint: "/app/.docker/entrypoint"
     ports:
     - "3000:3000"
     tmpfs: /app/hitobito/tmp/pids
     volumes:
     - ./:/app
     - seed:/seed
+    command: [ "rails", "server", "-b", "0.0.0.0" ]
 
   worker:
     <<: *app
@@ -27,19 +29,18 @@ services:
     - mail
     - cache
 
-  test: &test
-    build:
-      context: .
-      target: test
+  test:
+    <<: *app
     depends_on:
     - db-test
-    env_file: .docker/app.env
+    ports: []
     environment:
       RAILS_DB_NAME: hitobito_test
       RAILS_DB_HOST: db-test
-    tmpfs: /app/hitobito/tmp/pids
+      RAILS_ENV: test
     volumes:
     - ./:/app
+    command: [ "rspec" ]
 
   app-test:
     <<: *test
@@ -50,9 +51,7 @@ services:
   # Dependencies
 
   mail:
-    build:
-      context: .
-      target: base
+    build: .
     command: [ mailcatcher, -f, --ip, '0.0.0.0' ]
     ports:
     - "1080:1080"


### PR DESCRIPTION
In my opinion this simplifies the setup and consolidates all environment related configuration in one file (e.g. the compose loads `.docker/app.env`, but has some envs in build…).